### PR TITLE
added pagination to listings endpoint

### DIFF
--- a/backend/ths/listings/tests.py
+++ b/backend/ths/listings/tests.py
@@ -2,7 +2,8 @@ from datetime import date
 
 from rest_framework import status
 from rest_framework.test import APITestCase
-from .models import Listing, Assignment
+
+from .models import Assignment, Listing
 
 
 class ListingList(APITestCase):
@@ -24,10 +25,18 @@ class ListingList(APITestCase):
         response = self.client.get("/listings/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_get_paginated_resp_200(self):
+        response = self.client.get("/listings/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+
     def test_get_data(self):
         response = self.client.get("/listings/")
         self.assertEqual(
-            response.data,
+            response.json()["results"],
             [
                 {
                     "first_name": self.listing_1.first_name,

--- a/backend/ths/listings/views.py
+++ b/backend/ths/listings/views.py
@@ -6,4 +6,6 @@ from .serializers import ListingSerializer
 
 class ListingList(generics.ListAPIView):
     serializer_class = ListingSerializer
-    queryset = Listing.objects.all()
+
+    def get_queryset(self):
+        return Listing.objects.all().prefetch_related("pets", "assignments")

--- a/backend/ths/ths/settings.py
+++ b/backend/ths/ths/settings.py
@@ -125,3 +125,8 @@ STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 2,  # or 100 depending on your needs
+}


### PR DESCRIPTION
**Summary**
This PR aims to add in a fix which would ensure that the listing endpoint is not returning all listings per request. as this could lead to scaling issues. To resolve this a paginated response has been introduced. I have also added another suggestion within the "Notes for Reviewers" section

**Changes**

- Change 1: Added REST_FRAMEWORK config.
- Change 2: added a get_queryset method in the listing view.

**Testing**
Added the below tests:
- test_get_paginated_resp_200

Linked Issues
This PR would need to be merged into master first, and then the corresponding changes from master merged into "feature/allow_assignment_creation". This is to avoid  any braking changes which could occur on tests which have not been updated to include the pagination changes

Notes for Reviewers
Another way of reducing the listing endpoint scaling issue is: Caching of heavy repeated requests using Redis.